### PR TITLE
Notify callback as each broker is stopped.

### DIFF
--- a/api/src/main/java/io/kroxylicious/testing/kafka/api/KafkaCluster.java
+++ b/api/src/main/java/io/kroxylicious/testing/kafka/api/KafkaCluster.java
@@ -7,6 +7,7 @@
 package io.kroxylicious.testing.kafka.api;
 
 import java.util.Map;
+import java.util.function.Consumer;
 import java.util.function.Predicate;
 
 /**
@@ -62,9 +63,9 @@ public interface KafkaCluster extends AutoCloseable {
      *
      * @param nodeIdPredicate  predicate that returns true if the node identified by the given nodeId should be restarted
      * @param terminationStyle the style of termination used to shut down the broker(s).
-     * @param onBrokersStopped callback to invoked when all brokers are stopped, before restart commences. may be null.
+     * @param onBrokerStopped  callback to invoked when all brokers are stopped, before restart commences. may be null.
      */
-    void restartBrokers(Predicate<Integer> nodeIdPredicate, TerminationStyle terminationStyle, Runnable onBrokersStopped);
+    void restartBrokers(Predicate<Integer> nodeIdPredicate, TerminationStyle terminationStyle, Consumer<Integer> onBrokerStopped);
 
     /**
      * stops the cluster.

--- a/api/src/main/java/io/kroxylicious/testing/kafka/api/KafkaCluster.java
+++ b/api/src/main/java/io/kroxylicious/testing/kafka/api/KafkaCluster.java
@@ -55,15 +55,15 @@ public interface KafkaCluster extends AutoCloseable {
      * implementation is unable to support the requested style of termination. In this case, the implementation
      * is free to use an alternative termination style instead.
      * <br/>
-     * The caller may provide an <code>onBrokersStopped</code> runnable.  If not null, the runnable will be invoked,
-     * exactly once, when all the requested brokers are stopped. The restart of the brokers will not commence until
-     * this method returns.  Behaviour is not defined if the callable throws unchecked exceptions.  Furthermore, it
-     * must not attempt to mutate the cluster (that is, make calls to methods such as {@link KafkaCluster#addBroker()}).
+     * The caller may provide an <code>onBrokerStopped</code> Consumer.  If not null, the consumer will be invoked,
+     * once, per broker matching the predicate, as each broker is <em>stopped</em>. The roll of the matching brokers
+     * will not commence until this method returns.  Behaviour is not defined if the callable throws unchecked exceptions.
+     * Furthermore, it must not attempt to mutate the cluster (that is, make calls to methods such as {@link KafkaCluster#addBroker()}).
      * There is no guarantee made about the thread used to execute the callback.
      *
      * @param nodeIdPredicate  predicate that returns true if the node identified by the given nodeId should be restarted
      * @param terminationStyle the style of termination used to shut down the broker(s).
-     * @param onBrokerStopped  callback to invoked when all brokers are stopped, before restart commences. may be null.
+     * @param onBrokerStopped  callback to invoked when each broker is stopped, before restart commences. may be null.
      */
     void restartBrokers(Predicate<Integer> nodeIdPredicate, TerminationStyle terminationStyle, Consumer<Integer> onBrokerStopped);
 

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/invm/InVMKafkaCluster.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/invm/InVMKafkaCluster.java
@@ -385,7 +385,9 @@ public class InVMKafkaCluster implements KafkaCluster, KafkaClusterConfig.KafkaE
         if (await) {
             nodeMap.forEach((brokerId, server) -> {
                 server.awaitShutdown();
-                onBrokerStopped.accept(brokerId);
+                if (onBrokerStopped != null) {
+                    onBrokerStopped.accept(brokerId);
+                };
             });
         }
     }

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/testcontainers/TestcontainersKafkaCluster.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/testcontainers/TestcontainersKafkaCluster.java
@@ -373,7 +373,9 @@ public class TestcontainersKafkaCluster implements Startable, KafkaCluster, Kafk
                         inspectContainer.exec();
                     }
                     catch (NotFoundException e) {
-                        onBrokerStopped.accept(brokerId);
+                        if (onBrokerStopped != null) {
+                            onBrokerStopped.accept(brokerId);
+                        }
                         return true;
                     }
                     return false;

--- a/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/BeforeEachTest.java
+++ b/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/BeforeEachTest.java
@@ -5,15 +5,16 @@
  */
 package io.kroxylicious.testing.kafka.junit5ext;
 
-import io.kroxylicious.testing.kafka.api.KafkaCluster;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import java.util.List;
-import java.util.concurrent.TimeUnit;
+import io.kroxylicious.testing.kafka.api.KafkaCluster;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.testcontainers.shaded.org.awaitility.Awaitility.await;


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix
- Enhancement / new feature
- Refactoring
- Documentation

### Description

Convert `Runnable onBrokersStopped` to `Consumer<Integer> onBrokerStopped`.

### Additional Context

I think it makes for a more flexible interaction model and for a simpler test case. 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
