### PR TITLE
Reflection rabbit hole

### DIFF
--- a/api/src/main/java/io/kroxylicious/testing/kafka/api/KafkaCluster.java
+++ b/api/src/main/java/io/kroxylicious/testing/kafka/api/KafkaCluster.java
@@ -106,6 +106,13 @@ public interface KafkaCluster extends AutoCloseable {
     String getBootstrapServers();
 
     /**
+     * Gets the bootstrap controllers for this cluster
+     * @return bootstrap controllers
+     * @throws UnsupportedOperationException zookeeper based clusters do not support this operation.
+     */
+    String getBootstrapControllers() throws UnsupportedOperationException;
+
+    /**
      * Gets the cluster id
      * @return The cluster id for KRaft-based clusters, otherwise null;
      */
@@ -132,4 +139,16 @@ public interface KafkaCluster extends AutoCloseable {
      * @return mutable configuration map
      */
     Map<String, Object> getKafkaClientConfiguration(String user, String password);
+
+    /**
+     * Gets the kafka configuration for making connections to the controllers of this cluster as required by the
+     * {@code org.apache.kafka.clients.admin.AdminClient}. Details such the bootstrap and SASL configuration
+     * are provided automatically.
+     * The returned map is guaranteed to be mutable and is unique to the caller.
+     *
+     * @return mutable configuration map
+     * @throws UnsupportedOperationException zookeeper based clusters do not support this operation.
+     */
+    Map<String, Object> getControllerAdminClientConfiguration() throws UnsupportedOperationException;
+
 }

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/clients/CloseableAdmin.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/clients/CloseableAdmin.java
@@ -17,6 +17,8 @@ import java.util.Set;
 import org.apache.kafka.clients.admin.AbortTransactionOptions;
 import org.apache.kafka.clients.admin.AbortTransactionResult;
 import org.apache.kafka.clients.admin.AbortTransactionSpec;
+import org.apache.kafka.clients.admin.AddRaftVoterOptions;
+import org.apache.kafka.clients.admin.AddRaftVoterResult;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.AlterClientQuotasOptions;
 import org.apache.kafka.clients.admin.AlterClientQuotasResult;
@@ -104,9 +106,12 @@ import org.apache.kafka.clients.admin.NewPartitionReassignment;
 import org.apache.kafka.clients.admin.NewPartitions;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.admin.OffsetSpec;
+import org.apache.kafka.clients.admin.RaftVoterEndpoint;
 import org.apache.kafka.clients.admin.RecordsToDelete;
 import org.apache.kafka.clients.admin.RemoveMembersFromConsumerGroupOptions;
 import org.apache.kafka.clients.admin.RemoveMembersFromConsumerGroupResult;
+import org.apache.kafka.clients.admin.RemoveRaftVoterOptions;
+import org.apache.kafka.clients.admin.RemoveRaftVoterResult;
 import org.apache.kafka.clients.admin.RenewDelegationTokenOptions;
 import org.apache.kafka.clients.admin.RenewDelegationTokenResult;
 import org.apache.kafka.clients.admin.UnregisterBrokerOptions;
@@ -672,6 +677,16 @@ public record CloseableAdmin(Admin instance) implements Admin, AutoCloseable {
     @Override
     public Uuid clientInstanceId(Duration timeout) {
         return instance.clientInstanceId(timeout);
+    }
+
+    @Override
+    public AddRaftVoterResult addRaftVoter(int i, Uuid uuid, Set<RaftVoterEndpoint> set, AddRaftVoterOptions addRaftVoterOptions) {
+        return instance.addRaftVoter(i, uuid, set, addRaftVoterOptions);
+    }
+
+    @Override
+    public RemoveRaftVoterResult removeRaftVoter(int i, Uuid uuid, RemoveRaftVoterOptions removeRaftVoterOptions) {
+        return instance.removeRaftVoter(i, uuid, removeRaftVoterOptions);
     }
 
     @Override

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/common/KafkaClusterConfig.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/common/KafkaClusterConfig.java
@@ -619,6 +619,12 @@ public class KafkaClusterConfig {
         return kafkaConfig;
     }
 
+    public Map<String, Object> getControllerAdminClientConfigForCluster(String bootstrapControllers) {
+        var kafkaConfig = new HashMap<String, Object>();
+        kafkaConfig.put("bootstrap.controllers", bootstrapControllers);
+        return kafkaConfig;
+    }
+
     private void buildSecurityProtocolConfig(Map<String, Object> kafkaConfig) {
         String clientTrustStoreFilePath;
         String clientTrustStorePassword;

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/invm/InVMKafkaCluster.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/invm/InVMKafkaCluster.java
@@ -260,6 +260,15 @@ public class InVMKafkaCluster implements KafkaCluster, KafkaClusterConfig.KafkaE
         return buildBrokerList(nodeId -> getEndpointPair(Listener.EXTERNAL, nodeId));
     }
 
+    @Override
+    public String getBootstrapControllers() {
+        if (!clusterConfig.isKraftMode()) {
+            throw new UnsupportedOperationException("Zookeeper based clusters don't support this operation");
+        }
+
+        return buildBrokerList(nodeId -> getEndpointPair(Listener.CONTROLLER, nodeId));
+    }
+
     private synchronized String buildBrokerList(Function<Integer, KafkaClusterConfig.KafkaEndpoints.EndpointPair> endpointFunc) {
         return servers.keySet().stream()
                 .filter(this::isBroker)
@@ -276,6 +285,11 @@ public class InVMKafkaCluster implements KafkaCluster, KafkaClusterConfig.KafkaE
     @Override
     public Map<String, Object> getKafkaClientConfiguration(String user, String password) {
         return clusterConfig.getConnectConfigForCluster(getBootstrapServers(), user, password);
+    }
+
+    @Override
+    public Map<String, Object> getControllerAdminClientConfiguration() {
+        return clusterConfig.getControllerAdminClientConfigForCluster(getBootstrapControllers());
     }
 
     @Override

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/invm/ScramUtils.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/invm/ScramUtils.java
@@ -5,17 +5,26 @@
  */
 package io.kroxylicious.testing.kafka.invm;
 
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Base64;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
 
 import org.apache.kafka.common.metadata.UserScramCredentialRecord;
 import org.apache.kafka.common.security.scram.ScramCredential;
+import org.apache.kafka.common.security.scram.internals.ScramFormatter;
 import org.apache.kafka.common.security.scram.internals.ScramMechanism;
+import org.apache.kafka.server.common.ApiMessageAndVersion;
+import org.jetbrains.annotations.NotNull;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
-import kafka.tools.StorageTool;
-import net.sourceforge.argparse4j.inf.Namespace;
-import scala.jdk.javaapi.CollectionConverters;
 
 final class ScramUtils {
 
@@ -27,25 +36,272 @@ final class ScramUtils {
         return new ScramCredential(uscr.salt(), uscr.storedKey(), uscr.serverKey(), uscr.iterations());
     }
 
-    @NonNull
-    static List<UserScramCredentialRecord> getScramCredentialRecords(String saslMechanism, Map<String, String> users) {
+    static List<UserScramCredentialRecord> getUserScramCredentialRecords(List<String> addScram) {
+        try {
+            return ScramParser.parse(addScram).stream()
+                    .map(ApiMessageAndVersion::message)
+                    .map(UserScramCredentialRecord.class::cast)
+                    .toList();
+        }
+        catch (Exception e) {
+            throw new RuntimeException("Failed to create SCRAM users", e);
+        }
+    }
+
+    @NotNull
+    static List<String> toKafkaScramArguments(String saslMechanism, Map<String, String> users) {
         var scramMechanism = ScramMechanism.forMechanismName(saslMechanism);
         if (scramMechanism == null) {
             throw new IllegalArgumentException("unexpected scram mechanism " + saslMechanism);
         }
 
-        var addScram = users
+        return users
                 .entrySet()
                 .stream()
-                .map(e -> scramMechanism.mechanismName() + "=" + toKafkaScramCredentialsFormat(e.getKey(), e.getValue()))
+                .map(e -> scramMechanism.mechanismName() + "=" + toKafkaScramArguments(e.getKey(), e.getValue()))
                 .toList();
-
-        var n = new Namespace(Map.of("add_scram", addScram));
-        return CollectionConverters.asJava(StorageTool.getUserScramCredentialRecords(n).get());
     }
 
     @NonNull
-    private static String toKafkaScramCredentialsFormat(String username, String password) {
+    private static String toKafkaScramArguments(String username, String password) {
         return "[name=%s,password=%s]".formatted(username, password);
+    }
+
+    /** Copied from Kafka 3.9 ScramParser */
+    private static class ScramParser {
+        static List<ApiMessageAndVersion> parse(List<String> arguments) throws Exception {
+            List<ApiMessageAndVersion> records = new ArrayList<>();
+            for (String argument : arguments) {
+                Map.Entry<ScramMechanism, String> entry = parsePerMechanismArgument(argument);
+                PerMechanismData data = new PerMechanismData(entry.getKey(), entry.getValue());
+                records.add(new ApiMessageAndVersion(data.toRecord(), (short) 0));
+            }
+            return records;
+        }
+
+        static Map.Entry<ScramMechanism, String> parsePerMechanismArgument(String input) {
+            input = input.trim();
+            int equalsIndex = input.indexOf('=');
+            if (equalsIndex < 0) {
+                throw new FormatterException("Failed to find equals sign in SCRAM " +
+                        "argument '" + input + "'");
+            }
+            String mechanismString = input.substring(0, equalsIndex);
+            String configString = input.substring(equalsIndex + 1);
+            ScramMechanism mechanism = ScramMechanism.forMechanismName(mechanismString);
+            if (mechanism == null) {
+                throw new FormatterException("The add-scram mechanism " + mechanismString +
+                        " is not supported.");
+            }
+            if (!configString.startsWith("[")) {
+                throw new FormatterException("Expected configuration string to start with [");
+            }
+            if (!configString.endsWith("]")) {
+                throw new FormatterException("Expected configuration string to end with ]");
+            }
+            return new AbstractMap.SimpleImmutableEntry<>(mechanism,
+                    configString.substring(1, configString.length() - 1));
+        }
+
+        static final class PerMechanismData {
+            private final ScramMechanism mechanism;
+            private final String configuredName;
+            private final Optional<byte[]> configuredSalt;
+            private final OptionalInt configuredIterations;
+            private final Optional<String> configuredPasswordString;
+            private final Optional<byte[]> configuredSaltedPassword;
+
+            PerMechanismData(
+                             ScramMechanism mechanism,
+                             String configuredName,
+                             Optional<byte[]> configuredSalt,
+                             OptionalInt configuredIterations,
+                             Optional<String> configuredPasswordString,
+                             Optional<byte[]> configuredSaltedPassword) {
+                this.mechanism = mechanism;
+                this.configuredName = configuredName;
+                this.configuredSalt = configuredSalt;
+                this.configuredIterations = configuredIterations;
+                this.configuredPasswordString = configuredPasswordString;
+                this.configuredSaltedPassword = configuredSaltedPassword;
+            }
+
+            PerMechanismData(
+                             ScramMechanism mechanism,
+                             String configString) {
+                this.mechanism = mechanism;
+                String[] configComponents = configString.split(",");
+                Map<String, String> components = new TreeMap<>();
+                for (String configComponent : configComponents) {
+                    Map.Entry<String, String> entry = splitTrimmedConfigStringComponent(configComponent);
+                    components.put(entry.getKey(), entry.getValue());
+                }
+                this.configuredName = components.remove("name");
+                if (this.configuredName == null) {
+                    throw new FormatterException("You must supply 'name' to add-scram");
+                }
+
+                String saltString = components.remove("salt");
+                if (saltString == null) {
+                    this.configuredSalt = Optional.empty();
+                }
+                else {
+                    try {
+                        this.configuredSalt = Optional.of(Base64.getDecoder().decode(saltString));
+                    }
+                    catch (IllegalArgumentException e) {
+                        throw new FormatterException("Failed to decode given salt: " + saltString, e);
+                    }
+                }
+                String iterationsString = components.remove("iterations");
+                if (iterationsString == null) {
+                    this.configuredIterations = OptionalInt.empty();
+                }
+                else {
+                    try {
+                        this.configuredIterations = OptionalInt.of(Integer.parseInt(iterationsString));
+                    }
+                    catch (NumberFormatException e) {
+                        throw new FormatterException("Failed to parse iterations count: " + iterationsString, e);
+                    }
+                }
+                String passwordString = components.remove("password");
+                String saltedPasswordString = components.remove("saltedpassword");
+                if (passwordString == null) {
+                    if (saltedPasswordString == null) {
+                        throw new FormatterException("You must supply one of 'password' or 'saltedpassword' " +
+                                "to add-scram");
+                    }
+                    else if (!configuredSalt.isPresent()) {
+                        throw new FormatterException("You must supply 'salt' with 'saltedpassword' to add-scram");
+                    }
+                    try {
+                        this.configuredPasswordString = Optional.empty();
+                        this.configuredSaltedPassword = Optional.of(Base64.getDecoder().decode(saltedPasswordString));
+                    }
+                    catch (IllegalArgumentException e) {
+                        throw new FormatterException("Failed to decode given saltedPassword: " +
+                                saltedPasswordString, e);
+                    }
+                }
+                else {
+                    this.configuredPasswordString = Optional.of(passwordString);
+                    this.configuredSaltedPassword = Optional.empty();
+                }
+                if (!components.isEmpty()) {
+                    throw new FormatterException("Unknown SCRAM configurations: " +
+                            components.keySet().stream().collect(Collectors.joining(", ")));
+                }
+            }
+
+            byte[] salt() throws Exception {
+                if (configuredSalt.isPresent()) {
+                    return configuredSalt.get();
+                }
+                return new ScramFormatter(mechanism).secureRandomBytes();
+            }
+
+            int iterations() {
+                if (configuredIterations.isPresent()) {
+                    return configuredIterations.getAsInt();
+                }
+                return 4096;
+            }
+
+            byte[] saltedPassword(byte[] salt, int iterations) throws Exception {
+                if (configuredSaltedPassword.isPresent()) {
+                    return configuredSaltedPassword.get();
+                }
+                return new ScramFormatter(mechanism).saltedPassword(
+                        configuredPasswordString.get(),
+                        salt,
+                        iterations);
+            }
+
+            UserScramCredentialRecord toRecord() throws Exception {
+                ScramFormatter formatter = new ScramFormatter(mechanism);
+                byte[] salt = salt();
+                int iterations = iterations();
+                if (iterations < mechanism.minIterations()) {
+                    throw new FormatterException("The 'iterations' value must be >= " +
+                            mechanism.minIterations() + " for add-scram using " + mechanism);
+                }
+                if (iterations > mechanism.maxIterations()) {
+                    throw new FormatterException("The 'iterations' value must be <= " +
+                            mechanism.maxIterations() + " for add-scram using " + mechanism);
+                }
+                byte[] saltedPassword = saltedPassword(salt, iterations);
+                return new UserScramCredentialRecord().setName(configuredName).setMechanism(mechanism.type()).setSalt(salt)
+                        .setStoredKey(formatter.storedKey(formatter.clientKey(saltedPassword))).setServerKey(formatter.serverKey(saltedPassword))
+                        .setIterations(iterations);
+            }
+
+            @Override
+            public boolean equals(Object o) {
+                if (o == null || (!(o.getClass().equals(PerMechanismData.class))))
+                    return false;
+                PerMechanismData other = (PerMechanismData) o;
+                return mechanism.equals(other.mechanism) &&
+                        configuredName.equals(other.configuredName) &&
+                        Arrays.equals(configuredSalt.orElseGet(() -> null),
+                                other.configuredSalt.orElseGet(() -> null))
+                        &&
+                        configuredIterations.equals(other.configuredIterations) &&
+                        configuredPasswordString.equals(other.configuredPasswordString) &&
+                        Arrays.equals(configuredSaltedPassword.orElseGet(() -> null),
+                                other.configuredSaltedPassword.orElseGet(() -> null));
+            }
+
+            @Override
+            public int hashCode() {
+                return Objects.hash(mechanism,
+                        configuredName,
+                        configuredSalt,
+                        configuredIterations,
+                        configuredPasswordString,
+                        configuredSaltedPassword);
+            }
+
+            @Override
+            public String toString() {
+                return "PerMechanismData" +
+                        "(mechanism=" + mechanism +
+                        ", configuredName=" + configuredName +
+                        ", configuredSalt=" + configuredSalt.map(v -> Arrays.toString(v)) +
+                        ", configuredIterations=" + configuredIterations +
+                        ", configuredPasswordString=" + configuredPasswordString +
+                        ", configuredSaltedPassword=" + configuredSaltedPassword.map(v -> Arrays.toString(v)) +
+                        ")";
+            }
+        }
+
+        static Map.Entry<String, String> splitTrimmedConfigStringComponent(String input) {
+            int i;
+            for (i = 0; i < input.length(); i++) {
+                if (input.charAt(i) == '=') {
+                    break;
+                }
+            }
+            if (i == input.length()) {
+                throw new FormatterException("No equals sign found in SCRAM component: " + input);
+            }
+            String value = input.substring(i + 1);
+            if (value.length() >= 2) {
+                if (value.startsWith("\"") && value.endsWith("\"")) {
+                    value = value.substring(1, value.length() - 1);
+                }
+            }
+            return new AbstractMap.SimpleImmutableEntry<>(input.substring(0, i), value);
+        }
+    }
+
+    public static class FormatterException extends RuntimeException {
+        public FormatterException(String what) {
+            super(what);
+        }
+
+        public FormatterException(String what, Exception cause) {
+            super(what, cause);
+        }
     }
 }

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/testcontainers/TestcontainersKafkaCluster.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/testcontainers/TestcontainersKafkaCluster.java
@@ -274,6 +274,11 @@ public class TestcontainersKafkaCluster implements Startable, KafkaCluster, Kafk
         return buildBrokerList(nodeId -> this.getEndpointPair(Listener.EXTERNAL, nodeId));
     }
 
+    @Override
+    public String getBootstrapControllers() {
+        throw new UnsupportedOperationException();
+    }
+
     private synchronized String buildBrokerList(Function<Integer, KafkaClusterConfig.KafkaEndpoints.EndpointPair> endpointFunc) {
         return nodes.keySet().stream()
                 .filter(this::isBroker)
@@ -588,6 +593,11 @@ public class TestcontainersKafkaCluster implements Startable, KafkaCluster, Kafk
     @Override
     public Map<String, Object> getKafkaClientConfiguration(String user, String password) {
         return clusterConfig.getConnectConfigForCluster(getBootstrapServers(), user, password);
+    }
+
+    @Override
+    public Map<String, Object> getControllerAdminClientConfiguration() {
+        throw new UnsupportedOperationException();
     }
 
     @Override

--- a/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/TemplateTest.java
+++ b/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/TemplateTest.java
@@ -171,6 +171,9 @@ class TemplateTest {
         return Stream.of(
                 version(Version.LATEST_RELEASE),
                 version(Version.LATEST_SNAPSHOT),
+                version("3.9.0"),
+                version("3.8.0"),
+                version("3.7.0"),
                 version("3.6.0"),
                 version("3.5.1"),
                 version("3.4.0"),

--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
         <skipUTs>${skipTests}</skipUTs>
 
         <junit.version>5.11.3</junit.version>
-        <kafka.version>3.8.0</kafka.version>
+        <kafka.version>3.9.0</kafka.version>
         <testcontainers.version>1.20.3</testcontainers.version>
         <lombok.version>1.18.34</lombok.version>
         <assertj-core.version>3.26.3</assertj-core.version>


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

Code cleanup around the use of reflection when preparing log dirs

### Additional Context

I felt there was a lot of boilerplate code `prepareLogDirsForKraftKafka39Plus` which obscured what as actually being done. I thought it was possible to simplify things a bit by extracting a method but things got a bit more complicated. 

So I'm not convinced this makes things easier to read or not and even if it does is it worth the extra code? I thought it was easier to have that discussion on an additional PR than as comments on the original. I'm happy to drop and delete this if thats the consensus. 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
